### PR TITLE
Enable optional OpenAI API usage

### DIFF
--- a/faster_ds/LLM/__init__.py
+++ b/faster_ds/LLM/__init__.py
@@ -1,12 +1,41 @@
 """Utility helpers for interacting with Large Language Models."""
 
 from typing import Any
+import os
+
+try:  # Optional OpenAI dependency
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
 
 
 def send_to_llm(message: Any) -> None:
-    """Send information to an LLM.
+    """Send information to an LLM via the OpenAI API if available.
 
-    Currently this is a simple stub that prints the provided message. In a real
-    environment this would forward the data to a connected LLM service.
+    The function always prints the message to stdout to preserve the previous
+    behaviour which is relied upon in tests. If the ``openai`` package is
+    installed and the ``OPENAI_API_KEY`` environment variable is set, the
+    message is also sent to OpenAI's chat completion endpoint. Any errors during
+    the API call are silently ignored so that the absence of network access does
+    not break local execution.
     """
+
+    # Always print the message for logging purposes
     print(f"[LLM]: {message}")
+
+    if openai is None:  # pragma: no cover - optional dependency
+        return
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:  # pragma: no cover - optional dependency
+        return
+
+    openai.api_key = api_key
+    try:  # pragma: no cover - avoid failing tests without network
+        openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": str(message)}],
+        )
+    except Exception:
+        # Network or authentication issues should not crash the caller
+        pass

--- a/faster_ds/ML/regression.py
+++ b/faster_ds/ML/regression.py
@@ -1,11 +1,41 @@
-from sklearn.metrics import r2_score
-from sklearn.metrics import mean_absolute_error
-from sklearn.metrics import mean_squared_error
+import pandas as pd
+import sklearn
+from sklearn.metrics import r2_score, mean_absolute_error, mean_squared_error
+from sklearn.model_selection import train_test_split
 
+from faster_ds.LLM import send_to_llm
 
 
 class Model:
-    """Placeholder model class for regression algorithms."""
+    """Simple regression model wrapper with optional LLM reporting."""
 
-    pass
+    def __init__(
+        self,
+        model: sklearn.base.BaseEstimator,
+        X: pd.DataFrame,
+        y: pd.Series,
+        test_size: float = 0.2,
+        send_to_llm_flag: bool = False,
+    ) -> None:
+        self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(
+            X, y, test_size=test_size
+        )
+        self.model = model
+        self.model.fit(self.X_train, self.y_train)
+        self.y_pred = self.model.predict(self.X_test)
+        self.metrics = self._compute_metrics()
+        if send_to_llm_flag:
+            self.send_metrics_to_llm()
+
+    def _compute_metrics(self) -> dict:
+        """Return basic regression metrics as a dictionary."""
+        return {
+            "r2": r2_score(self.y_test, self.y_pred),
+            "mae": mean_absolute_error(self.y_test, self.y_pred),
+            "mse": mean_squared_error(self.y_test, self.y_pred),
+        }
+
+    def send_metrics_to_llm(self) -> None:
+        """Send computed metrics to an attached LLM service."""
+        send_to_llm(f"Regression metrics: {self.metrics}")
     

--- a/faster_ds/ML/time_series.py
+++ b/faster_ds/ML/time_series.py
@@ -1,12 +1,19 @@
 import pandas as pd
 
-
+from faster_ds.LLM import send_to_llm
 
 
 class TimeSeries:
     """Base interface for time series operations."""
 
-    def __init__(self):
+    def __init__(self, series: pd.Series | None = None, send_to_llm_flag: bool = False) -> None:
         """Initialize the time series helper."""
-        pass
 
+        self.series = pd.Series(series) if series is not None else pd.Series(dtype=float)
+        if send_to_llm_flag:
+            self.send_summary_to_llm()
+
+    def send_summary_to_llm(self) -> None:
+        """Send a statistical summary of the series to an attached LLM."""
+        summary = self.series.describe().to_dict()
+        send_to_llm(f"Time series summary: {summary}")


### PR DESCRIPTION
## Summary
- extend `send_to_llm` to optionally use OpenAI's API
- expand regression model with metric reporting and OpenAI hook
- implement simple time series class with OpenAI hook

## Testing
- `pytest -q`