### PR TITLE
Extend Python compatibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11'
+        python-version: '3.13'
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-slim
+ARG PYTHON_VERSION=3.11
+FROM python:${PYTHON_VERSION}-slim
 
 WORKDIR /app
 

--- a/README.rst
+++ b/README.rst
@@ -177,7 +177,7 @@ new_df = remove_to_lot_missing(df, threshold=0.7)
 # fake(sample) data
 ```{BASH}
 
-python3.11 -i generate_fake_data.py
+python3 -i generate_fake_data.py
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/fuwiak/faster_llm"
 packages = [{ include = "faster_llm" }]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = ">=3.11,<3.14"
 numpy = ">=1.24.1"
 pandas = ">=1.5.2"
 scikit-learn = ">=1.2.0"

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,8 @@ if __name__ == "__main__":
         "Operating System :: Unix",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ]
     """
     Full list can be found at: https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # content of: tox.ini , put in same dir as setup.py
 # for more info: http://tox.readthedocs.io/en/latest/config.html
 [tox]
-envlist = py311
+envlist = py311, py312, py313
 
 [testenv]
 deps =


### PR DESCRIPTION
## Summary
- loosen supported Python versions in pyproject
- expand tox matrix to 3.11-3.13
- update classifiers for Python 3.12/3.13
- generalize README usage instructions
- allow Docker build to specify Python version
- adjust CI workflows for newer Python versions

## Testing
- `pytest -q`
